### PR TITLE
Update GaspumpJetton.ts

### DIFF
--- a/src/contracts/GaspumpJetton.ts
+++ b/src/contracts/GaspumpJetton.ts
@@ -5,14 +5,14 @@ import { TradeState } from './TradeState';
 
 // loaders
 function loadTupleBondingCurveParams(source: TupleReader) {
-    let _mathScale = source.items[0];
-    let _coinScale = source.items[1];
-    let _alpha = source.items[2];
-    let _beta = source.items[3];
-    let _maxSupply = source.items[4];
-    let _bondingCurveMaxSupply = source.items[5];
-    let _maxTonAmount = source.items[6];
-    let _dexFeeAmount = source.items[7];
+    let _mathScale = source.pop();
+    let _coinScale = source.pop();
+    let _alpha = source.pop();
+    let _beta = source.pop();
+    let _maxSupply = source.pop();
+    let _bondingCurveMaxSupply = source.pop();
+    let _maxTonAmount = source.pop();
+    let _dexFeeAmount = source.pop();
     return { $$type: 'BondingCurveParams' as const, mathScale: _mathScale, coinScale: _coinScale, alpha: _alpha, beta: _beta, maxSupply: _maxSupply, bondingCurveMaxSupply: _bondingCurveMaxSupply, maxTonAmount: _maxTonAmount, dexFeeAmount: _dexFeeAmount };
 }
 

--- a/src/contracts/GaspumpJetton.ts
+++ b/src/contracts/GaspumpJetton.ts
@@ -5,14 +5,14 @@ import { TradeState } from './TradeState';
 
 // loaders
 function loadTupleBondingCurveParams(source: TupleReader) {
-    let _mathScale = source.readBigNumber();
-    let _coinScale = source.readBigNumber();
-    let _alpha = source.readBigNumber();
-    let _beta = source.readBigNumber();
-    let _maxSupply = source.readBigNumber();
-    let _bondingCurveMaxSupply = source.readBigNumber();
-    let _maxTonAmount = source.readBigNumber();
-    let _dexFeeAmount = source.readBigNumber();
+    let _mathScale = source.items[0];
+    let _coinScale = source.items[1];
+    let _alpha = source.items[2];
+    let _beta = source.items[3];
+    let _maxSupply = source.items[4];
+    let _bondingCurveMaxSupply = source.items[5];
+    let _maxTonAmount = source.items[6];
+    let _dexFeeAmount = source.items[7];
     return { $$type: 'BondingCurveParams' as const, mathScale: _mathScale, coinScale: _coinScale, alpha: _alpha, beta: _beta, maxSupply: _maxSupply, bondingCurveMaxSupply: _bondingCurveMaxSupply, maxTonAmount: _maxTonAmount, dexFeeAmount: _dexFeeAmount };
 }
 


### PR DESCRIPTION
readTuple updated in latest ton core. 

I tried to use this SDK until got this error:

            throw Error('Not a number');
                  ^

Error: Not a number
    at TupleReader.readBigNumber (C:\Users\Admin\Desktop\Wallet-js-api\node_modules\@ton\core\dist\tuple\reader.js:41:19)
    at loadTupleBondingCurveParams (C:\Users\Admin\Desktop\Wallet-js-api\node_modules\@gaspump\sdk\dist\src\contracts\GaspumpJetton.js:10:29)
    at loadTupleFullJettonData (C:\Users\Admin\Desktop\Wallet-js-api\node_modules\@gaspump\sdk\dist\src\contracts\GaspumpJetton.js:30:33)
    at GaspumpJetton.getFullJettonData (C:\Users\Admin\Desktop\Wallet-js-api\node_modules\@gaspump\sdk\dist\src\contracts\GaspumpJetton.js:169:24)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    
    Then after some debug points I understood that readTuple now also unpack all values inside, so we can parse it like simple tuple with .items[index]